### PR TITLE
Deprecate this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,3 @@
 # eID Belgium for Chocolatey
-## Presentation
-This repository contains the source code for a Chocolatey package allowing automated and silent installation of the [Belgian electronic ID card middleware](http://eid.belgium.be).
 
-## Usage
-The package can be accessed directly from the [Chocolatey gallery](https://chocolatey.org/packages/eid-belgium). To use it, first [install Chocolatey](https://chocolatey.org/install) than open a PowerShell/Command Prompt as an Administrator and type the following command:
-
-```powershell
-choco install eid-belgium
-```
-
-The install process will install the eID Belgium middleware in seconds.
-
-## Problems and bugs reports
-You can report bugs or installation problems by accessing the package's gallery page, than simply use the built-in Disqus widget or the *Contact Maintainers* link from the left menu.
-
----
-[Chris Vanclercq](https://vanclercq.me), 2016-2017.
+This repository is now deprecated as this package has been made official by integrating the Chocolatey Core Team repository thanks to [this pull request](https://github.com/chocolatey/chocolatey-coreteampackages/pull/1110).


### PR DESCRIPTION
As requested by upstream when a package has been elected as a core team package, the old repository must be deprecated.